### PR TITLE
Update to the current state of technology

### DIFF
--- a/demo-project/pom.xml
+++ b/demo-project/pom.xml
@@ -4,35 +4,31 @@
 
 	<groupId>com.example</groupId>
 	<artifactId>demo-project</artifactId>
-	<version>0</version>
+	<version>0.0.1-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>Demo Project</name>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+		<failOnMissingWebXml>false</failOnMissingWebXml>
 	</properties>
 
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-war-plugin</artifactId>
-				<version>3.0.0</version>
-				<configuration>
-					<failOnMissingWebXml>false</failOnMissingWebXml>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>ca.eqv.jtsc</groupId>
 				<artifactId>jtsc-maven-plugin</artifactId>
-				<version>0.1.0.BUILD-SNAPSHOT</version>
+				<version>1.0.0-SNAPSHOT</version>
 				<dependencies>
-					<!-- Optionally, use a different version of TypeScript. -->
+					<!-- Current default TypeScript version is 4.5.5 -->
+					<!-- Optionally, use a different version of TypeScript available from https://mvnrepository.com/artifact/org.webjars.npm/typescript -->
 					<!--
 					<dependency>
 						<groupId>org.webjars.npm</groupId>
 						<artifactId>typescript</artifactId>
-						<version>1.8.10</version>
+						<version>3.9.10</version>
 					</dependency>
 					-->
 				</dependencies>

--- a/jtsc-core/pom.xml
+++ b/jtsc-core/pom.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>ca.eqv.jtsc</groupId>
 		<artifactId>jtsc</artifactId>
-		<version>0.1.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jtsc-core</artifactId>
-	<version>0.1.0.BUILD-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>JVM tsc wrapper - core</name>
@@ -24,6 +26,19 @@
 	</build>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.graalvm.sdk</groupId>
+			<artifactId>graal-sdk</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.graalvm.js</groupId>
+			<artifactId>js</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.graalvm.js</groupId>
+			<artifactId>js-scriptengine</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.webjars.npm</groupId>
 			<artifactId>typescript</artifactId>

--- a/jtsc-core/src/main/javascript/ca/eqv/jtsc/JVMSystem.js
+++ b/jtsc-core/src/main/javascript/ca/eqv/jtsc/JVMSystem.js
@@ -58,7 +58,7 @@ ts.sys = (function getSystem() {
 		if (writeByteOrderMark) {
 			data = "\uFEFF" + data;
 		}
-		Files.write(Paths.get(path), new JavaString(data).getBytes("UTF-8"));
+		Files.writeString(Paths.get(path), data);
 	}
 
 	function resolvePath(path) {

--- a/jtsc-executable/pom.xml
+++ b/jtsc-executable/pom.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>ca.eqv.jtsc</groupId>
 		<artifactId>jtsc</artifactId>
-		<version>0.1.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jtsc-executable</artifactId>
-	<version>0.1.0.BUILD-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>JVM tsc wrapper - executable</name>

--- a/jtsc-maven-plugin/pom.xml
+++ b/jtsc-maven-plugin/pom.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>ca.eqv.jtsc</groupId>
 		<artifactId>jtsc</artifactId>
-		<version>0.1.0.BUILD-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>jtsc-maven-plugin</artifactId>
-	<version>0.1.0.BUILD-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>JVM tsc wrapper - Maven plugin</name>
-
-	<prerequisites>
-		<maven>3.1</maven>
-	</prerequisites>
 
 	<build>
 		<plugins>
@@ -35,10 +33,12 @@
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>ca.eqv.jtsc</groupId>
 	<artifactId>jtsc</artifactId>
-	<version>0.1.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>
+		<javase.version>11</javase.version>
+		<graalvm.version>22.0.0.2</graalvm.version>
+		<typescript.version>4.5.5</typescript.version>
+
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.java.target>1.8</project.build.java.target>
-		<org.typescriptlang.typescript.version>1.8.10</org.typescriptlang.typescript.version>
+		<maven.compiler.source>${javase.version}</maven.compiler.source>
+		<maven.compiler.target>${javase.version}</maven.compiler.target>
 	</properties>
 
 	<name>JVM tsc wrapper</name>
@@ -28,27 +35,23 @@
 			<plugins>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.5.1</version>
-					<configuration>
-						<source>${project.build.java.target}</source>
-						<target>${project.build.java.target}</target>
-					</configuration>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.2.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.2.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.3.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-plugin-plugin</artifactId>
-					<version>3.5</version>
+					<version>3.6.4</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -57,24 +60,39 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>org.webjars.npm</groupId>
-				<artifactId>typescript</artifactId>
-				<version>${org.typescriptlang.typescript.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>${project.groupId}</groupId>
 				<artifactId>jtsc-core</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.graalvm.sdk</groupId>
+				<artifactId>graal-sdk</artifactId>
+				<version>${graalvm.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.graalvm.js</groupId>
+				<artifactId>js</artifactId>
+				<version>${graalvm.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.graalvm.js</groupId>
+				<artifactId>js-scriptengine</artifactId>
+				<version>${graalvm.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.webjars.npm</groupId>
+				<artifactId>typescript</artifactId>
+				<version>${typescript.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.apache.maven</groupId>
 				<artifactId>maven-plugin-api</artifactId>
-				<version>3.3.9</version>
+				<version>3.8.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
-				<version>3.5</version>
+				<version>3.6.4</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
- Bump Java version to 11 (17 is unnecessary for now)
- Swap out Nashorn for GraalVM (because Nashorn is deprecated since Java 11 and GraalVM is MUCH faster than it)
- Bump TypeScript default version to 4.5.5
- Rewrite compiler to be compatible with TypeScript 1.x/2.x/3.x/4.x

Feel free to merge.

I will be continuing to use the omnifaces/tsc-maven-plugin:master to further adjust the tsc-maven-plugin to fit my needs (I don't need the executable) and publish the sole plugin to Maven Central.